### PR TITLE
Add coverage configuration file

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,2 @@
+[report]
+omit = */shell/*


### PR DESCRIPTION
Exclude shell application which is not really part of the pyzigbee library.